### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/jdx/sigstore-verification/compare/v0.2.1...v0.2.2) - 2026-03-20
+
+### Fixed
+
+- generate Cargo.lock before security audit ([#24](https://github.com/jdx/sigstore-verification/pull/24))
+
+### Other
+
+- *(deps)* update jdx/mise-action action to v4 ([#31](https://github.com/jdx/sigstore-verification/pull/31))
+- *(deps)* update swatinem/rust-cache digest to e18b497 ([#30](https://github.com/jdx/sigstore-verification/pull/30))
+- *(deps)* update release-plz/action digest to 1528104 ([#29](https://github.com/jdx/sigstore-verification/pull/29))
+- *(deps)* update jdx/mise-action digest to 5228313 ([#28](https://github.com/jdx/sigstore-verification/pull/28))
+- *(deps)* update jdx/mise-action digest to e79ddf6 ([#27](https://github.com/jdx/sigstore-verification/pull/27))
+- *(deps)* pin dependencies ([#26](https://github.com/jdx/sigstore-verification/pull/26))
+
 ## [0.2.1](https://github.com/jdx/sigstore-verification/compare/v0.2.0...v0.2.1) - 2026-02-15
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigstore-verification"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 authors = ["Jeff Dickey (@jdx)"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `sigstore-verification`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/jdx/sigstore-verification/compare/v0.2.1...v0.2.2) - 2026-03-20

### Fixed

- generate Cargo.lock before security audit ([#24](https://github.com/jdx/sigstore-verification/pull/24))

### Other

- *(deps)* update jdx/mise-action action to v4 ([#31](https://github.com/jdx/sigstore-verification/pull/31))
- *(deps)* update swatinem/rust-cache digest to e18b497 ([#30](https://github.com/jdx/sigstore-verification/pull/30))
- *(deps)* update release-plz/action digest to 1528104 ([#29](https://github.com/jdx/sigstore-verification/pull/29))
- *(deps)* update jdx/mise-action digest to 5228313 ([#28](https://github.com/jdx/sigstore-verification/pull/28))
- *(deps)* update jdx/mise-action digest to e79ddf6 ([#27](https://github.com/jdx/sigstore-verification/pull/27))
- *(deps)* pin dependencies ([#26](https://github.com/jdx/sigstore-verification/pull/26))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the crate version and updates the changelog; no functional code changes are included.
> 
> **Overview**
> **Release bump to `v0.2.2`.** Updates `Cargo.toml` version from `0.2.1` to `0.2.2` and adds a `0.2.2` entry to `CHANGELOG.md` (noting a fix to generate `Cargo.lock` before security audit plus dependency/workflow maintenance items).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69a2727b3b240cbf922e1d8a4d36fdd011023cfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->