### PR TITLE
feat: add builder pattern for customizable GitHub API URL

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,4 @@
 use crate::{AttestationError, Result};
-use reqwest::Url;
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use serde::{Deserialize, Serialize};
 
@@ -11,6 +10,39 @@ pub struct AttestationClient {
     client: reqwest::Client,
     base_url: String,
     github_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AttestationClientBuilder {
+    base_url: Option<String>,
+    github_token: Option<String>,
+}
+
+impl AttestationClientBuilder {
+    pub fn base_url(mut self, url: &str) -> Self {
+        self.base_url = Some(url.trim_end_matches('/').to_string());
+        self
+    }
+
+    pub fn github_token(mut self, token: &str) -> Self {
+        self.github_token = Some(token.to_string());
+        self
+    }
+
+    pub fn build(self) -> Result<AttestationClient> {
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
+
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()?;
+
+        Ok(AttestationClient {
+            client,
+            base_url: self.base_url.unwrap_or_else(|| GITHUB_API_URL.to_string()),
+            github_token: self.github_token,
+        })
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -75,36 +107,31 @@ pub struct Signature {
 
 impl AttestationClient {
     pub fn new(github_token: Option<&str>) -> Result<Self> {
-        let mut headers = HeaderMap::new();
-        headers.insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
+        let mut builder = Self::builder();
+        if let Some(token) = github_token {
+            builder = builder.github_token(token);
+        }
+        builder.build()
+    }
 
-        let client = reqwest::Client::builder()
-            .default_headers(headers)
-            .build()?;
-
-        Ok(Self {
-            client,
-            base_url: GITHUB_API_URL.to_string(),
-            github_token: github_token.map(|s| s.to_string()),
-        })
+    pub fn builder() -> AttestationClientBuilder {
+        AttestationClientBuilder::default()
     }
 
     fn github_headers(&self, url: &str) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
-        if let Ok(url) = Url::parse(url) {
-            if url.host_str() == Some("api.github.com") {
-                if let Some(token) = &self.github_token {
-                    headers.insert(
-                        AUTHORIZATION,
-                        HeaderValue::from_str(&format!("Bearer {}", token))
-                            .map_err(|e| AttestationError::Api(e.to_string()))?,
-                    );
-                }
+        if url.starts_with(&self.base_url) {
+            if let Some(token) = &self.github_token {
                 headers.insert(
-                    "x-github-api-version",
-                    HeaderValue::from_static("2022-11-28"),
+                    AUTHORIZATION,
+                    HeaderValue::from_str(&format!("Bearer {}", token))
+                        .map_err(|e| AttestationError::Api(e.to_string()))?,
                 );
             }
+            headers.insert(
+                "x-github-api-version",
+                HeaderValue::from_static("2022-11-28"),
+            );
         }
         Ok(headers)
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -120,7 +120,8 @@ impl AttestationClient {
 
     fn github_headers(&self, url: &str) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
-        if url.starts_with(&self.base_url) {
+        let base_with_slash = format!("{}/", self.base_url);
+        if url.starts_with(&base_with_slash) || url == self.base_url {
             if let Some(token) = &self.github_token {
                 headers.insert(
                     AUTHORIZATION,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,10 @@ pub mod verifiers;
 pub mod verify;
 
 // Re-export commonly used types
-pub use api::{Attestation, AttestationClient, FetchParams, MessageDigest, MessageSignature};
+pub use api::{
+    Attestation, AttestationClient, AttestationClientBuilder, FetchParams, MessageDigest,
+    MessageSignature,
+};
 pub use bundle::{ParsedBundle, SlsaProvenance};
 pub use sources::{ArtifactRef, AttestationSource};
 pub use verifiers::{Policy, VerificationResult, Verifier};

--- a/tests/attestation_client_builder.rs
+++ b/tests/attestation_client_builder.rs
@@ -1,0 +1,120 @@
+use mockito::Server;
+use sigstore_verification::AttestationClient;
+use sigstore_verification::FetchParams;
+
+#[test]
+fn test_builder_default_base_url() {
+    let client = AttestationClient::builder().build().unwrap();
+    // Should succeed without any configuration
+    assert!(format!("{:?}", client).contains("api.github.com"));
+}
+
+#[test]
+fn test_builder_custom_base_url() {
+    let client = AttestationClient::builder()
+        .base_url("https://my-proxy.internal/github")
+        .build()
+        .unwrap();
+    assert!(format!("{:?}", client).contains("my-proxy.internal"));
+}
+
+#[test]
+fn test_builder_strips_trailing_slash() {
+    let client = AttestationClient::builder()
+        .base_url("https://my-proxy.internal/github/")
+        .build()
+        .unwrap();
+    let debug = format!("{:?}", client);
+    assert!(debug.contains("my-proxy.internal/github\""));
+    assert!(!debug.contains("github/\""));
+}
+
+#[test]
+fn test_new_delegates_to_builder() {
+    let client = AttestationClient::new(Some("test-token")).unwrap();
+    let debug = format!("{:?}", client);
+    assert!(debug.contains("api.github.com"));
+    assert!(debug.contains("test-token"));
+}
+
+#[tokio::test]
+async fn test_custom_base_url_sends_requests_to_configured_host() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("GET", "/repos/owner/repo/attestations/sha256:abc123")
+        .match_query(mockito::Matcher::UrlEncoded("per_page".into(), "10".into()))
+        .match_header("x-github-api-version", "2022-11-28")
+        .match_header("authorization", "Bearer test-token")
+        .with_status(200)
+        .with_body(r#"{"attestations":[]}"#)
+        .create_async()
+        .await;
+
+    let client = AttestationClient::builder()
+        .base_url(&server.url())
+        .github_token("test-token")
+        .build()
+        .unwrap();
+
+    let params = FetchParams {
+        owner: "owner".to_string(),
+        repo: Some("owner/repo".to_string()),
+        digest: "sha256:abc123".to_string(),
+        limit: 10,
+        predicate_type: None,
+    };
+
+    let result = client.fetch_attestations(params).await.unwrap();
+    assert!(result.is_empty());
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_auth_headers_not_sent_to_different_host() {
+    let mut api_server = Server::new_async().await;
+    let mut other_server = Server::new_async().await;
+
+    // The API server returns an attestation with a bundle_url pointing to a different host
+    let bundle_url = format!("{}/bundle", other_server.url());
+    let api_mock = api_server
+        .mock("GET", "/repos/owner/repo/attestations/sha256:abc123")
+        .match_query(mockito::Matcher::Any)
+        .with_status(200)
+        .with_body(format!(
+            r#"{{"attestations":[{{"bundle":null,"bundle_url":"{}"}}]}}"#,
+            bundle_url
+        ))
+        .create_async()
+        .await;
+
+    // The other server should NOT receive auth headers
+    let bundle_mock = other_server
+        .mock("GET", "/bundle")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .match_header("x-github-api-version", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_body(
+            r#"{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json","dsseEnvelope":{"payload":"dGVzdA==","payloadType":"application/vnd.in-toto+json","signatures":[{"sig":"dGVzdA=="}]}}"#,
+        )
+        .create_async()
+        .await;
+
+    let client = AttestationClient::builder()
+        .base_url(&api_server.url())
+        .github_token("secret-token")
+        .build()
+        .unwrap();
+
+    let params = FetchParams {
+        owner: "owner".to_string(),
+        repo: Some("owner/repo".to_string()),
+        digest: "sha256:abc123".to_string(),
+        limit: 10,
+        predicate_type: None,
+    };
+
+    let result = client.fetch_attestations(params).await.unwrap();
+    assert_eq!(result.len(), 1);
+    api_mock.assert_async().await;
+    bundle_mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary
- Adds `AttestationClientBuilder` with a builder pattern for constructing `AttestationClient`
- Supports setting a custom `base_url` to override the default `https://api.github.com`, enabling use behind reverse proxies
- Fixes `github_headers` to send auth tokens and API version headers to the configured base URL (not just `api.github.com`)

## Usage
```rust
let client = AttestationClient::builder()
    .base_url("https://my-proxy.internal/github")
    .github_token("ghp_xxx")
    .build()?;
```

The existing `AttestationClient::new()` API is unchanged.

Closes #32

## Test plan
- [x] `cargo check` passes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how auth and API-version headers are conditionally attached to outbound HTTP requests; mistakes could break attestation fetching or leak tokens to unintended endpoints.
> 
> **Overview**
> Adds an `AttestationClientBuilder` to construct `AttestationClient` with an optional custom `base_url` (defaulting to `https://api.github.com`) and optional GitHub token, while keeping `AttestationClient::new()` by delegating to the builder.
> 
> Updates `github_headers` to apply `Authorization` and `x-github-api-version` headers based on whether a request URL matches the configured `base_url` (instead of hard-coding `api.github.com`), preventing headers from being sent to non-matching hosts (e.g., external `bundle_url`s).
> 
> Re-exports `AttestationClientBuilder` from `lib.rs` and adds `mockito` tests covering default/custom base URLs, trailing-slash normalization, header injection for custom hosts, and ensuring headers are not sent to different hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1406408e438159e2aabfcc40957997b67978e4db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->