### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/jdx/sigstore-verification/compare/v0.2.2...v0.2.3) - 2026-04-15
+
+### Fixed
+
+- accept non-SLSA GitHub attestations (e.g. SPDX SBOM) ([#40](https://github.com/jdx/sigstore-verification/pull/40))
+- *(deps)* update rust crate sha2 to 0.11 ([#38](https://github.com/jdx/sigstore-verification/pull/38))
+
+### Other
+
+- *(deps)* update obi1kenobi/cargo-semver-checks-action digest to 6b69fcf ([#37](https://github.com/jdx/sigstore-verification/pull/37))
+
 ## [0.2.2](https://github.com/jdx/sigstore-verification/compare/v0.2.1...v0.2.2) - 2026-04-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigstore-verification"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 authors = ["Jeff Dickey (@jdx)"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `sigstore-verification`: 0.2.2 -> 0.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/jdx/sigstore-verification/compare/v0.2.2...v0.2.3) - 2026-04-15

### Fixed

- accept non-SLSA GitHub attestations (e.g. SPDX SBOM) ([#40](https://github.com/jdx/sigstore-verification/pull/40))
- *(deps)* update rust crate sha2 to 0.11 ([#38](https://github.com/jdx/sigstore-verification/pull/38))

### Other

- *(deps)* update obi1kenobi/cargo-semver-checks-action digest to 6b69fcf ([#37](https://github.com/jdx/sigstore-verification/pull/37))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the crate version and updates the changelog for the `v0.2.3` release, with no code changes.
> 
> **Overview**
> Prepares the `v0.2.3` release by bumping `Cargo.toml` from `0.2.2` to `0.2.3` and adding the corresponding `CHANGELOG.md` entry (including notes about accepting non-SLSA GitHub attestations and dependency updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c5252530bcdb12ae2bd0ca84935cfc92dfe0a8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->