### PR TITLE
fix: accept non-SLSA GitHub attestations (e.g. SPDX SBOM)

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -145,19 +145,18 @@ pub fn parse_slsa_provenance(payload: &[u8]) -> Result<SlsaProvenance> {
         .and_then(|v| v.as_str())
         .ok_or_else(|| AttestationError::Verification("Missing predicateType".into()))?;
 
-    if !predicate_type.starts_with("https://slsa.dev/provenance/") {
-        return Err(AttestationError::Verification(format!(
-            "Not a SLSA provenance statement: {}",
-            predicate_type
-        )));
-    }
-
-    // Extract workflow information from predicate
-    let predicate = statement
-        .get("predicate")
-        .ok_or_else(|| AttestationError::Verification("Missing predicate".into()))?;
-
-    let workflow_ref = extract_workflow_ref(predicate)?;
+    // For SLSA provenance statements, extract workflow info from the predicate.
+    // For other attestation types (e.g. SPDX SBOM), the bundle is still a
+    // valid sigstore attestation — we just don't have workflow metadata from
+    // the predicate and will rely on the certificate for identity checks.
+    let workflow_ref = if predicate_type.starts_with("https://slsa.dev/provenance/") {
+        let predicate = statement
+            .get("predicate")
+            .ok_or_else(|| AttestationError::Verification("Missing predicate".into()))?;
+        extract_workflow_ref(predicate)?
+    } else {
+        None
+    };
 
     Ok(SlsaProvenance {
         predicate_type: predicate_type.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,13 +142,16 @@ pub async fn verify_github_attestation(
     // Create API client
     let client = AttestationClient::new(token)?;
 
-    // Fetch attestations from GitHub
+    // Fetch attestations from GitHub. Don't filter by predicate type — some
+    // projects publish non-SLSA attestations (e.g. SPDX SBOM), and filtering
+    // would hide them even though they are still valid sigstore bundles we
+    // can verify via certificate + DSSE signature.
     let params = FetchParams {
         owner: owner.to_string(),
         repo: Some(format!("{}/{}", owner, repo)),
         digest: format!("sha256:{}", digest),
         limit: 30,
-        predicate_type: Some("https://slsa.dev/provenance/v1".to_string()),
+        predicate_type: None,
     };
 
     let attestations = client.fetch_attestations(params).await?;


### PR DESCRIPTION
## Summary
- Drop the hardcoded `predicate_type=https://slsa.dev/provenance/v1` filter in `verify_github_attestation` so the GitHub attestations API returns all attestations for the artifact digest.
- Tolerate non-SLSA in-toto statements in `parse_slsa_provenance`: keep the SLSA workflow extraction when the predicate is SLSA, otherwise return `workflow_ref: None` instead of erroring.

## Why
Projects that publish only SBOM attestations (e.g. [`gleam-lang/gleam`](https://github.com/gleam-lang/gleam) ships an SPDX SBOM attestation but no SLSA provenance) were rejected with `NoAttestations`, even though the sigstore bundle is otherwise valid. Surfaced by jdx/mise#9092 — `mise install gleam@latest` fails with:

```
GitHub artifact attestations verification failed: No attestations found
```

while `gh attestation verify --predicate-type https://spdx.dev/Document/v2.3 …` succeeds.

The verification path still uses the Fulcio certificate + DSSE signature path, so callers that pass `signer_workflow` continue to have workflow identity enforced via the cert SAN. The SLSA verifier (`verifiers::slsa`) is untouched and still rejects non-SLSA predicates.

## Test plan
- [x] `cargo build` / `cargo test --lib`
- [x] Manual end-to-end: downloaded `gleam-v1.15.4-x86_64-unknown-linux-musl.tar.gz` and called `verify_github_attestation("gleam-lang", "gleam", …)` — now returns `Ok(true)` (previously `NoAttestations`).
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens GitHub attestation verification to include non-SLSA predicate types, which changes what bundles are accepted and how workflow metadata is derived. Risk is moderate because it affects security-adjacent verification behavior, though signature/certificate verification still applies.
> 
> **Overview**
> GitHub attestation verification now fetches *all* attestations for an artifact digest by removing the hardcoded SLSA `predicate_type` filter in `verify_github_attestation`.
> 
> `parse_slsa_provenance` no longer rejects non-SLSA predicate types; it conditionally extracts `workflow_ref` only for SLSA provenance and otherwise returns `workflow_ref: None`, allowing valid non-SLSA attestations (e.g., SPDX SBOM) to pass through bundle verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4808cdc5c3f6f6ab96d4663d100b4a99cc19bf14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->