### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/jdx/sigstore-verification/compare/v0.2.3...v0.2.4) - 2026-04-15
+
+### Fixed
+
+- accept Fulcio certificate issuer names ([#41](https://github.com/jdx/sigstore-verification/pull/41))
+
 ## [0.2.3](https://github.com/jdx/sigstore-verification/compare/v0.2.2...v0.2.3) - 2026-04-15
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigstore-verification"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 authors = ["Jeff Dickey (@jdx)"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `sigstore-verification`: 0.2.3 -> 0.2.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.4](https://github.com/jdx/sigstore-verification/compare/v0.2.3...v0.2.4) - 2026-04-15

### Fixed

- accept Fulcio certificate issuer names ([#41](https://github.com/jdx/sigstore-verification/pull/41))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the crate version and updates the changelog for the v0.2.4 release, with no functional code changes in the diff.
> 
> **Overview**
> Bumps `sigstore-verification` from `0.2.3` to `0.2.4` in `Cargo.toml` and adds a `CHANGELOG.md` entry for the v0.2.4 release (noting the fix to accept Fulcio certificate issuer names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 976a5b25b5952d92bb9b3831adcfa3b041402009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->