### PR TITLE
fix: accept dotcom releases SAN without slash

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -263,7 +263,9 @@ pub fn verify_certificate(cert_pem: &str) -> Result<CertificateInfo> {
                                         .to_string(),
                                 );
                             }
-                        } else if uri_str.starts_with("https://dotcom.releases.github.com/") {
+                        } else if uri_str == "https://dotcom.releases.github.com"
+                            || uri_str.starts_with("https://dotcom.releases.github.com/")
+                        {
                             repository = Some("dotcom.releases.github.com".to_string());
                         }
                     }
@@ -1014,6 +1016,17 @@ mod tests {
     #[test]
     fn accepts_dotcom_releases_identity() {
         let info = cert_info(None, Some("dotcom.releases.github.com"));
+        assert!(has_github_certificate_identity(&info));
+    }
+
+    #[test]
+    fn extracts_dotcom_releases_identity_from_github_attestation_certificate() {
+        let cert = "MIICKzCCAbCgAwIBAgIUdkRBqOh332mFwwbiaqkdO+NCHGowCgYIKoZIzj0EAwMwODEVMBMGA1UEChMMR2l0SHViLCBJbmMuMR8wHQYDVQQDExZGdWxjaW8gSW50ZXJtZWRpYXRlIGwxMB4XDTI1MTExMzAwMDAwMFoXDTI2MTExMzAwMDAwMFowKjEVMBMGA1UEChMMR2l0SHViLCBJbmMuMREwDwYDVQQDEwhBdHRlc3RlcjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABGR+ZMdEcHEuf1YbMBlhXTtqPmyCqQAIDyQk+TVHPywC1ZNxk5LQlRb8Vol/XZA1utIrSNdt8lkoi3RdrOhOWlOjgaUwgaIwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMDMAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYEFJYm8uweBLpLZHSfo3kCjGBsvV8gMB8GA1UdIwQYMBaAFMDhuFKkS08+3no4EQbPSY6hRZszMC0GA1UdEQQmMCSGImh0dHBzOi8vZG90Y29tLnJlbGVhc2VzLmdpdGh1Yi5jb20wCgYIKoZIzj0EAwMDaQAwZgIxAN2T1WebCAcTXlyWDN4a+crAVMmFTR+zCiaknrR2MRG13xaDH28D6/ddwSCOsS3s/AIxAOVCzN/I7KBuRkVSlMsJRZxK1ZKkhxmhF2TSjI0Z2qY8I1zsXt5d0ZVT13WGAY5A7A==";
+        let info = super::verify_certificate(cert).unwrap();
+        assert_eq!(
+            info.repository.as_deref(),
+            Some("dotcom.releases.github.com")
+        );
         assert!(has_github_certificate_identity(&info));
     }
 


### PR DESCRIPTION
## Summary
- accept the exact https://dotcom.releases.github.com URI in GitHub artifact attestation certificates
- add a regression test using a real GitHub release attestation certificate

## Tests
- cargo test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small tweak to certificate SAN URI parsing plus a regression test; main impact is slightly broader acceptance of a specific GitHub hostname identity.
> 
> **Overview**
> Fixes GitHub attestation certificate parsing to recognize the exact `https://dotcom.releases.github.com` SAN (in addition to the `/...` form) when extracting the repository identity.
> 
> Adds a regression test that parses a real GitHub release attestation certificate and asserts `dotcom.releases.github.com` is extracted and treated as a valid GitHub identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5e3d13282a776398eb105561f76b20320ec4302. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->