### PR TITLE
chore: release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/jdx/sigstore-verification/compare/v0.2.4...v0.2.5) - 2026-04-15
+
+### Fixed
+
+- accept dotcom releases SAN without slash ([#43](https://github.com/jdx/sigstore-verification/pull/43))
+
 ## [0.2.4](https://github.com/jdx/sigstore-verification/compare/v0.2.3...v0.2.4) - 2026-04-15
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigstore-verification"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 authors = ["Jeff Dickey (@jdx)"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `sigstore-verification`: 0.2.4 -> 0.2.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.5](https://github.com/jdx/sigstore-verification/compare/v0.2.4...v0.2.5) - 2026-04-15

### Fixed

- accept dotcom releases SAN without slash ([#43](https://github.com/jdx/sigstore-verification/pull/43))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: updates the crate version and changelog with no functional code changes in this PR.
> 
> **Overview**
> Prepares the `v0.2.5` release by bumping the crate version in `Cargo.toml` and adding a `0.2.5` entry to `CHANGELOG.md` (noting the fix to accept dotcom releases SAN without a slash).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a360a8d5660d884d1b4e9b38b3495c932eaf4f6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->