### PR TITLE
feat: support custom GitHub API base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- support custom GitHub API base URL for `GitHubSource` and `verify_github_attestation`, enabling verification against GitHub Enterprise Server instances
+
 ## [0.2.5](https://github.com/jdx/sigstore-verification/compare/v0.2.4...v0.2.5) - 2026-04-15
 
 ### Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,11 +136,61 @@ pub async fn verify_github_attestation(
     token: Option<&str>,
     signer_workflow: Option<&str>,
 ) -> Result<bool> {
+    verify_github_attestation_inner(artifact_path, owner, repo, token, signer_workflow, None).await
+}
+
+/// Verify a GitHub artifact attestation against a custom GitHub API base URL
+/// (e.g. a GitHub Enterprise Server instance such as
+/// `https://github.enterprise.com/api/v3`).
+///
+/// # Arguments
+/// * `artifact_path` - Path to the artifact file to verify
+/// * `owner` - GitHub organization or user that owns the repository
+/// * `repo` - Repository name (without owner)
+/// * `token` - Optional GitHub token for API authentication
+/// * `signer_workflow` - Optional workflow path to verify against
+/// * `base_url` - Base URL of the GitHub API (e.g.
+///   `https://github.enterprise.com/api/v3`). The auth token is only sent to
+///   this host — bundle URLs pointing elsewhere are fetched unauthenticated.
+pub async fn verify_github_attestation_with_base_url(
+    artifact_path: &Path,
+    owner: &str,
+    repo: &str,
+    token: Option<&str>,
+    signer_workflow: Option<&str>,
+    base_url: &str,
+) -> Result<bool> {
+    verify_github_attestation_inner(
+        artifact_path,
+        owner,
+        repo,
+        token,
+        signer_workflow,
+        Some(base_url),
+    )
+    .await
+}
+
+async fn verify_github_attestation_inner(
+    artifact_path: &Path,
+    owner: &str,
+    repo: &str,
+    token: Option<&str>,
+    signer_workflow: Option<&str>,
+    base_url: Option<&str>,
+) -> Result<bool> {
     // Calculate artifact digest
     let digest = calculate_file_digest(artifact_path)?;
 
     // Create API client
-    let client = AttestationClient::new(token)?;
+    let mut client_builder = AttestationClient::builder();
+    if let Some(token) = token {
+        client_builder = client_builder.github_token(token);
+    }
+    if let Some(base_url) = base_url {
+        client_builder = client_builder.base_url(base_url);
+    }
+    let client = client_builder.build()?;
 
     // Fetch attestations from GitHub. Don't filter by predicate type — some
     // projects publish non-SLSA attestations (e.g. SPDX SBOM), and filtering

--- a/src/sources/github.rs
+++ b/src/sources/github.rs
@@ -118,6 +118,16 @@ impl GitHubSourceBuilder {
 
 #[async_trait]
 impl AttestationSource for GitHubSource {
+    /// Fetch attestations for an artifact from the configured GitHub API.
+    ///
+    /// Note: this filters the GitHub API response to SLSA provenance v1
+    /// (`https://slsa.dev/provenance/v1`) because `GitHubSource` is intended
+    /// for SLSA verification via the generic `verify_artifact` + `SlsaVerifier`
+    /// flow. Callers who need the unfiltered attestation set (e.g. non-SLSA
+    /// bundles such as SPDX SBOMs) should use
+    /// [`crate::verify_github_attestation`] /
+    /// [`crate::verify_github_attestation_with_base_url`], which send no
+    /// predicate filter, or drive [`AttestationClient`] directly.
     async fn fetch_attestations(&self, artifact: &ArtifactRef) -> Result<Vec<Attestation>> {
         let params = FetchParams {
             owner: self.owner.clone(),

--- a/src/sources/github.rs
+++ b/src/sources/github.rs
@@ -11,15 +11,107 @@ pub struct GitHubSource {
 }
 
 impl GitHubSource {
+    /// Create a new `GitHubSource` targeting `https://api.github.com`.
     pub fn new(
         owner: impl Into<String>,
         repo: impl Into<String>,
         token: Option<&str>,
     ) -> Result<Self> {
-        Ok(Self {
-            client: AttestationClient::new(token)?,
+        let mut builder = Self::builder().owner(owner).repo(repo);
+        if let Some(token) = token {
+            builder = builder.token(token);
+        }
+        builder.build()
+    }
+
+    /// Create a new `GitHubSource` targeting a custom API base URL (e.g. a
+    /// GitHub Enterprise Server instance such as
+    /// `https://github.enterprise.com/api/v3`).
+    pub fn with_base_url(
+        owner: impl Into<String>,
+        repo: impl Into<String>,
+        token: Option<&str>,
+        base_url: &str,
+    ) -> Result<Self> {
+        let mut builder = Self::builder().owner(owner).repo(repo).base_url(base_url);
+        if let Some(token) = token {
+            builder = builder.token(token);
+        }
+        builder.build()
+    }
+
+    /// Create a new `GitHubSource` from an already-built [`AttestationClient`],
+    /// allowing the caller to configure the HTTP client (base URL, token, etc.)
+    /// independently.
+    pub fn with_client(
+        owner: impl Into<String>,
+        repo: impl Into<String>,
+        client: AttestationClient,
+    ) -> Self {
+        Self {
+            client,
             owner: owner.into(),
             repo: repo.into(),
+        }
+    }
+
+    /// Start building a `GitHubSource` with a fluent builder.
+    pub fn builder() -> GitHubSourceBuilder {
+        GitHubSourceBuilder::default()
+    }
+}
+
+/// Builder for [`GitHubSource`].
+#[derive(Debug, Default)]
+pub struct GitHubSourceBuilder {
+    owner: Option<String>,
+    repo: Option<String>,
+    token: Option<String>,
+    base_url: Option<String>,
+}
+
+impl GitHubSourceBuilder {
+    pub fn owner(mut self, owner: impl Into<String>) -> Self {
+        self.owner = Some(owner.into());
+        self
+    }
+
+    pub fn repo(mut self, repo: impl Into<String>) -> Self {
+        self.repo = Some(repo.into());
+        self
+    }
+
+    pub fn token(mut self, token: impl Into<String>) -> Self {
+        self.token = Some(token.into());
+        self
+    }
+
+    pub fn base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = Some(url.into());
+        self
+    }
+
+    pub fn build(self) -> Result<GitHubSource> {
+        let owner = self.owner.ok_or_else(|| {
+            crate::AttestationError::Api("GitHubSource: owner is required".into())
+        })?;
+        let repo = self
+            .repo
+            .ok_or_else(|| crate::AttestationError::Api("GitHubSource: repo is required".into()))?;
+
+        let mut client_builder = AttestationClient::builder();
+        if let Some(token) = self.token {
+            client_builder = client_builder.github_token(&token);
+        }
+        if let Some(base_url) = self.base_url {
+            client_builder = client_builder.base_url(&base_url);
+        }
+        let client = client_builder.build()?;
+
+        Ok(GitHubSource {
+            client,
+            owner,
+            repo,
         })
     }
 }

--- a/tests/github_source_base_url.rs
+++ b/tests/github_source_base_url.rs
@@ -1,0 +1,99 @@
+use mockito::Server;
+use sigstore_verification::sources::github::GitHubSource;
+use sigstore_verification::{ArtifactRef, AttestationClient, AttestationSource};
+
+#[tokio::test]
+async fn test_github_source_default_hits_api_github_com() {
+    let source = GitHubSource::new("owner", "repo", Some("token")).unwrap();
+    assert_eq!(source.source_type(), "GitHub");
+}
+
+#[tokio::test]
+async fn test_github_source_with_base_url_routes_to_custom_host() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("GET", "/repos/owner/repo/attestations/sha256:abc123")
+        .match_query(mockito::Matcher::Any)
+        .match_header("authorization", "Bearer ghes-token")
+        .match_header("x-github-api-version", "2022-11-28")
+        .with_status(200)
+        .with_body(r#"{"attestations":[]}"#)
+        .create_async()
+        .await;
+
+    let source =
+        GitHubSource::with_base_url("owner", "repo", Some("ghes-token"), &server.url()).unwrap();
+    let artifact = ArtifactRef::from_digest("sha256:abc123");
+
+    let result = source.fetch_attestations(&artifact).await.unwrap();
+    assert!(result.is_empty());
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_github_source_builder_routes_to_custom_host() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("GET", "/repos/owner/repo/attestations/sha256:abc123")
+        .match_query(mockito::Matcher::Any)
+        .match_header("authorization", "Bearer ghes-token")
+        .with_status(200)
+        .with_body(r#"{"attestations":[]}"#)
+        .create_async()
+        .await;
+
+    let source = GitHubSource::builder()
+        .owner("owner")
+        .repo("repo")
+        .token("ghes-token")
+        .base_url(server.url())
+        .build()
+        .unwrap();
+    let artifact = ArtifactRef::from_digest("sha256:abc123");
+
+    let result = source.fetch_attestations(&artifact).await.unwrap();
+    assert!(result.is_empty());
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_github_source_with_client_uses_provided_client() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("GET", "/repos/owner/repo/attestations/sha256:abc123")
+        .match_query(mockito::Matcher::Any)
+        .match_header("authorization", "Bearer preconfigured")
+        .with_status(200)
+        .with_body(r#"{"attestations":[]}"#)
+        .create_async()
+        .await;
+
+    let client = AttestationClient::builder()
+        .base_url(&server.url())
+        .github_token("preconfigured")
+        .build()
+        .unwrap();
+    let source = GitHubSource::with_client("owner", "repo", client);
+    let artifact = ArtifactRef::from_digest("sha256:abc123");
+
+    let result = source.fetch_attestations(&artifact).await.unwrap();
+    assert!(result.is_empty());
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_github_source_builder_requires_owner_and_repo() {
+    let err = GitHubSource::builder()
+        .repo("repo")
+        .build()
+        .err()
+        .expect("builder should fail without owner");
+    assert!(format!("{err}").contains("owner"));
+
+    let err = GitHubSource::builder()
+        .owner("owner")
+        .build()
+        .err()
+        .expect("builder should fail without repo");
+    assert!(format!("{err}").contains("repo"));
+}

--- a/tests/github_source_base_url.rs
+++ b/tests/github_source_base_url.rs
@@ -37,6 +37,7 @@ async fn test_github_source_builder_routes_to_custom_host() {
         .mock("GET", "/repos/owner/repo/attestations/sha256:abc123")
         .match_query(mockito::Matcher::Any)
         .match_header("authorization", "Bearer ghes-token")
+        .match_header("x-github-api-version", "2022-11-28")
         .with_status(200)
         .with_body(r#"{"attestations":[]}"#)
         .create_async()

--- a/tests/verify_github_attestation_base_url.rs
+++ b/tests/verify_github_attestation_base_url.rs
@@ -1,0 +1,47 @@
+//! Tests that `verify_github_attestation_with_base_url` routes API calls to
+//! the configured host (e.g. a GitHub Enterprise Server) instead of
+//! `api.github.com`.
+
+use mockito::Server;
+use sigstore_verification::{AttestationError, verify_github_attestation_with_base_url};
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+#[tokio::test]
+async fn test_verify_with_base_url_queries_custom_host() {
+    let mut server = Server::new_async().await;
+
+    // The artifact digest depends on the file contents, so match any digest
+    // path rather than precomputing it.
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"^/repos/owner/repo/attestations/sha256:.+$".into()),
+        )
+        .match_query(mockito::Matcher::Any)
+        .match_header("authorization", "Bearer ghes-token")
+        .match_header("x-github-api-version", "2022-11-28")
+        .with_status(200)
+        .with_body(r#"{"attestations":[]}"#)
+        .create_async()
+        .await;
+
+    let mut tmp = NamedTempFile::new().unwrap();
+    tmp.write_all(b"test artifact contents").unwrap();
+    tmp.flush().unwrap();
+
+    let result = verify_github_attestation_with_base_url(
+        tmp.path(),
+        "owner",
+        "repo",
+        Some("ghes-token"),
+        None,
+        &server.url(),
+    )
+    .await;
+
+    // No attestations in the mocked response — the function should report
+    // `NoAttestations`, but critically it must have hit the custom host.
+    assert!(matches!(result, Err(AttestationError::NoAttestations)));
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary

- Adds a `base_url` option to `GitHubSource` and `verify_github_attestation`, so callers can verify attestations published on GitHub Enterprise Server instances (e.g. `https://github.enterprise.com/api/v3`) instead of always targeting `api.github.com`.
- New surface (all additive, backward-compatible):
  - `GitHubSource::with_base_url(owner, repo, token, base_url)`
  - `GitHubSource::with_client(owner, repo, client)` — hand in a pre-built `AttestationClient`
  - `GitHubSource::builder()` fluent builder
  - `verify_github_attestation_with_base_url(...)` convenience wrapper mirroring `verify_github_attestation`
- Existing `GitHubSource::new` and `verify_github_attestation` keep their current behavior (default to `api.github.com`).

## Motivation

mise users who point the github backend at a GHES instance via `api_url = \"https://github.enterprise.com/api/v3\"` had their downloads succeed against GHES, but attestation verification then fell back to `api.github.com` and failed with a 401 because the GHES token isn't valid there. Details: https://github.com/jdx/mise/discussions/9176

The underlying `AttestationClient::builder().base_url(...)` already existed (#36); this PR plumbs it through the public `GitHubSource` and `verify_github_attestation` surfaces that callers actually use.

## Test plan

- [x] `cargo test` — all existing tests still pass (10+6+3 in existing suites).
- [x] New `tests/github_source_base_url.rs`: `GitHubSource::with_base_url`, `::with_client`, and `::builder()` all route requests to the configured host and send the auth token; `builder()` surfaces missing-field errors.
- [x] New `tests/verify_github_attestation_base_url.rs`: end-to-end test of `verify_github_attestation_with_base_url` against a mockito server, asserting the request hits the custom host with the right auth header.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all --check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes how GitHub API clients are constructed and where auth tokens are sent, which can affect attestation fetching/verification behavior across hosts (dotcom vs GHES). Additive APIs and new tests reduce regression risk, but misconfiguration could lead to unexpected unauthenticated requests.
> 
> **Overview**
> Enables attestation fetching and `verify_github_attestation` to target a *custom GitHub API base URL* (e.g. GitHub Enterprise Server) instead of always using `api.github.com`, by introducing `verify_github_attestation_with_base_url` and refactoring verification to build an `AttestationClient` with optional token + base URL.
> 
> Updates `GitHubSource` to support `with_base_url`, `with_client`, and a fluent `builder()` (with required-field validation), and adds mock-based tests to assert requests route to the configured host and include the expected auth/version headers. The changelog is updated to document the new capability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbe7653a8769d90ade28cfa63489af684b743a71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->