### PR TITLE
chore: release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/jdx/sigstore-verification/compare/v0.2.5...v0.2.6) - 2026-04-19
+
+### Added
+
+- support custom GitHub API base URL ([#45](https://github.com/jdx/sigstore-verification/pull/45))
+
 ### Added
 
 - support custom GitHub API base URL for `GitHubSource` and `verify_github_attestation`, enabling verification against GitHub Enterprise Server instances

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigstore-verification"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 authors = ["Jeff Dickey (@jdx)"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `sigstore-verification`: 0.2.5 -> 0.2.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.6](https://github.com/jdx/sigstore-verification/compare/v0.2.5...v0.2.6) - 2026-04-19

### Added

- support custom GitHub API base URL ([#45](https://github.com/jdx/sigstore-verification/pull/45))

### Added

- support custom GitHub API base URL for `GitHubSource` and `verify_github_attestation`, enabling verification against GitHub Enterprise Server instances
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the crate version and updates the changelog; no functional code changes are included.
> 
> **Overview**
> Bumps `sigstore-verification` from `0.2.5` to `0.2.6` and adds a `0.2.6` entry to `CHANGELOG.md` documenting support for a custom GitHub API base URL (including GitHub Enterprise Server use cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5cd2031df6cbeb70dc0ffcf250bc515510e71c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->