### PR TITLE
Avoid sigstore client build for attestation verification

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -405,7 +405,12 @@ async fn verify_with_sigstore_client(
 
     // Verify the signature
     if let Some(sig) = envelope.signatures.first() {
-        verify_dsse_signature(cert_bytes, &sig.sig, &envelope.payload)?;
+        verify_dsse_signature(
+            cert_bytes,
+            &sig.sig,
+            &envelope.payload,
+            &envelope.payload_type,
+        )?;
     }
 
     // Verify Rekor transparency log inclusion if available
@@ -465,7 +470,12 @@ fn is_fulcio_issuer(issuer: &str) -> bool {
 }
 
 /// Verify the DSSE signature
-fn verify_dsse_signature(cert_bytes: &[u8], signature: &str, payload: &str) -> Result<()> {
+fn verify_dsse_signature(
+    cert_bytes: &[u8],
+    signature: &str,
+    payload: &str,
+    payload_type: &str,
+) -> Result<()> {
     // Parse the certificate to extract the public key
     let (_, cert) = X509Certificate::from_der(cert_bytes).map_err(|e| {
         AttestationError::Verification(format!("Failed to parse certificate: {}", e))
@@ -477,7 +487,7 @@ fn verify_dsse_signature(cert_bytes: &[u8], signature: &str, payload: &str) -> R
     })?;
 
     // Create the PAE (Pre-Authentication Encoding) for DSSE
-    let pae = create_dsse_pae("application/vnd.in-toto+json", payload.as_bytes());
+    let pae = create_dsse_pae(payload_type, payload.as_bytes());
 
     // Extract and verify based on the public key algorithm
     let public_key = cert.public_key();
@@ -959,7 +969,9 @@ fn has_github_certificate_identity(cert_info: &CertificateInfo) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{CertificateInfo, has_github_certificate_identity, is_fulcio_issuer};
+    use super::{
+        CertificateInfo, create_dsse_pae, has_github_certificate_identity, is_fulcio_issuer,
+    };
 
     fn cert_info(workflow_ref: Option<&str>, repository: Option<&str>) -> CertificateInfo {
         CertificateInfo {
@@ -1031,5 +1043,11 @@ mod tests {
     fn rejects_missing_github_identity() {
         let info = cert_info(None, None);
         assert!(!has_github_certificate_identity(&info));
+    }
+
+    #[test]
+    fn creates_dsse_pae_with_supplied_payload_type() {
+        let pae = create_dsse_pae("application/spdx+json", b"hello");
+        assert_eq!(pae, b"DSSEv1 21 application/spdx+json 5 hello");
     }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -397,6 +397,9 @@ async fn verify_with_sigstore_client(
         AttestationError::Verification("Could not fetch Sigstore trust root".into())
     })?;
 
+    // Temporary workaround: avoid constructing the sigstore client here until
+    // downstream consumers can pick up a sigstore release that includes the
+    // upstream Rekor-key parsing fix.
     // Verify the certificate chain against Fulcio roots
     verify_certificate_chain(cert_bytes, &trust_root)?;
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -3,7 +3,6 @@ use crate::{AttestationError, Result, api::Attestation};
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use log::debug;
 use sha2::{Digest, Sha256};
-use sigstore::cosign::{ClientBuilder, CosignCapabilities};
 use sigstore::trust::TrustRoot;
 use sigstore::trust::sigstore::SigstoreTrustRoot;
 use std::path::Path;
@@ -398,25 +397,18 @@ async fn verify_with_sigstore_client(
         AttestationError::Verification("Could not fetch Sigstore trust root".into())
     })?;
 
-    // Build the Sigstore client
-    let mut client = ClientBuilder::default()
-        .with_trust_repository(&*trust_root)
-        .map_err(|e| AttestationError::Verification(format!("Failed to build client: {}", e)))?
-        .build()
-        .map_err(|e| AttestationError::Verification(format!("Failed to build client: {}", e)))?;
-
     // Verify the certificate chain against Fulcio roots
-    verify_certificate_chain(&mut client, cert_bytes, &trust_root)?;
+    verify_certificate_chain(cert_bytes, &trust_root)?;
 
     // Verify the signature
     if let Some(sig) = envelope.signatures.first() {
-        verify_dsse_signature(&mut client, cert_bytes, &sig.sig, &envelope.payload)?;
+        verify_dsse_signature(cert_bytes, &sig.sig, &envelope.payload)?;
     }
 
     // Verify Rekor transparency log inclusion if available
     if let Some(tlog_entries) = &bundle.tlog_entries {
         for tlog_entry in tlog_entries {
-            verify_rekor_inclusion(&mut client, tlog_entry, &trust_root)?;
+            verify_rekor_inclusion(tlog_entry, &trust_root)?;
         }
     }
 
@@ -424,11 +416,7 @@ async fn verify_with_sigstore_client(
 }
 
 /// Verify the certificate chain against Fulcio roots
-fn verify_certificate_chain<T: CosignCapabilities>(
-    _client: &mut T,
-    cert_bytes: &[u8],
-    trust_root: &SigstoreTrustRoot,
-) -> Result<()> {
+fn verify_certificate_chain(cert_bytes: &[u8], trust_root: &SigstoreTrustRoot) -> Result<()> {
     // Parse the certificate
     use x509_parser::prelude::*;
     let (_, cert) = X509Certificate::from_der(cert_bytes).map_err(|e| {
@@ -474,12 +462,7 @@ fn is_fulcio_issuer(issuer: &str) -> bool {
 }
 
 /// Verify the DSSE signature
-fn verify_dsse_signature<T: CosignCapabilities>(
-    _client: &mut T,
-    cert_bytes: &[u8],
-    signature: &str,
-    payload: &str,
-) -> Result<()> {
+fn verify_dsse_signature(cert_bytes: &[u8], signature: &str, payload: &str) -> Result<()> {
     // Parse the certificate to extract the public key
     let (_, cert) = X509Certificate::from_der(cert_bytes).map_err(|e| {
         AttestationError::Verification(format!("Failed to parse certificate: {}", e))
@@ -689,8 +672,7 @@ fn create_dsse_pae(payload_type: &str, payload: &[u8]) -> Vec<u8> {
 }
 
 /// Verify inclusion in Rekor transparency log
-fn verify_rekor_inclusion<T: CosignCapabilities>(
-    _client: &mut T,
+fn verify_rekor_inclusion(
     tlog_entry: &serde_json::Value,
     trust_root: &SigstoreTrustRoot,
 ) -> Result<()> {


### PR DESCRIPTION
## Summary
Avoid building a `sigstore::cosign::Client` during GitHub attestation verification.

## Why
`sigstore-verification` currently fetches the Sigstore trust root and then builds a `sigstore` client before running its own local verification helpers. That client build is not actually needed for the checks this crate performs today.

On current trust roots, `sigstore 0.13.0` can fail while parsing one Rekor key from the trust root:

- Rekor key id: `cf1199155bddd051268d1f16ac5c0c75c009f6fb5a63f4177f8e18d7051e3fa0`
- key type: Ed25519 SPKI
- failure mode: the older `sigstore` release tries to parse Rekor keys through the default ECDSA scheme during client build

Upstream `sigstore-rs` `main` already contains a fix for that parsing path, but there is not a newer crates.io release than `0.13.0` yet. This change avoids the failing path entirely and keeps verification working in downstream consumers like `mise`.

## Change
- remove the unnecessary `ClientBuilder` construction in `verify_with_sigstore_client`
- call the existing local verification helpers directly
- drop the now-unused `CosignCapabilities` generic plumbing

## Verification
- `cargo test --quiet`
