### PR TITLE
chore: release v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7](https://github.com/jdx/sigstore-verification/compare/v0.2.6...v0.2.7) - 2026-04-22
+
+### Other
+
+- Avoid sigstore client build for attestation verification ([#47](https://github.com/jdx/sigstore-verification/pull/47))
+
 ## [0.2.6](https://github.com/jdx/sigstore-verification/compare/v0.2.5...v0.2.6) - 2026-04-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigstore-verification"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 authors = ["Jeff Dickey (@jdx)"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `sigstore-verification`: 0.2.6 -> 0.2.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.7](https://github.com/jdx/sigstore-verification/compare/v0.2.6...v0.2.7) - 2026-04-22

### Other

- Avoid sigstore client build for attestation verification ([#47](https://github.com/jdx/sigstore-verification/pull/47))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the crate version and updates the changelog, with no code or dependency changes.
> 
> **Overview**
> Prepares the `sigstore-verification` **v0.2.7** release by bumping the crate version in `Cargo.toml` and adding a new `CHANGELOG.md` entry for `0.2.7` (noting the attestation verification change from #47).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce966a5c50bd03bfa8b886f54de08e2eae61aaa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->