### PR TITLE
chore: release v0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8](https://github.com/jdx/sigstore-verification/compare/v0.2.7...v0.2.8) - 2026-05-03
+
+### Other
+
+- set dev profile debug to 1 ([#49](https://github.com/jdx/sigstore-verification/pull/49))
+
 ## [0.2.7](https://github.com/jdx/sigstore-verification/compare/v0.2.6...v0.2.7) - 2026-04-22
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigstore-verification"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2024"
 authors = ["Jeff Dickey (@jdx)"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `sigstore-verification`: 0.2.7 -> 0.2.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.8](https://github.com/jdx/sigstore-verification/compare/v0.2.7...v0.2.8) - 2026-05-03

### Other

- set dev profile debug to 1 ([#49](https://github.com/jdx/sigstore-verification/pull/49))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only (version bump and changelog update) with no functional code changes in this diff.
> 
> **Overview**
> Prepares the `v0.2.8` release by bumping the crate version in `Cargo.toml` from `0.2.7` to `0.2.8` and adding a corresponding `CHANGELOG.md` entry noting the dev-profile debug setting change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4559044147d162a8812aed5cd7243bca6c0f6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->