### PR TITLE
chore: release v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9](https://github.com/jdx/sigstore-verification/compare/v0.2.8...v0.2.9) - 2026-05-15
+
+### Fixed
+
+- *(deps)* update rust crate signature to v3 ([#52](https://github.com/jdx/sigstore-verification/pull/52))
+
+### Other
+
+- *(deps)* update release-plz/action digest to 064f4d1 ([#51](https://github.com/jdx/sigstore-verification/pull/51))
+
 ## [0.2.8](https://github.com/jdx/sigstore-verification/compare/v0.2.7...v0.2.8) - 2026-05-03
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigstore-verification"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2024"
 authors = ["Jeff Dickey (@jdx)"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `sigstore-verification`: 0.2.8 -> 0.2.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.9](https://github.com/jdx/sigstore-verification/compare/v0.2.8...v0.2.9) - 2026-05-15

### Fixed

- *(deps)* update rust crate signature to v3 ([#52](https://github.com/jdx/sigstore-verification/pull/52))

### Other

- *(deps)* update release-plz/action digest to 064f4d1 ([#51](https://github.com/jdx/sigstore-verification/pull/51))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the crate version and records release notes, with no code or runtime behavior changes in the diff.
> 
> **Overview**
> Prepares the `v0.2.9` release by updating `Cargo.toml` from `0.2.8` to `0.2.9` and adding a new `CHANGELOG.md` entry for `0.2.9` (noting the `signature` crate v3 dependency update and a `release-plz/action` digest bump).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b78eee3645494090ef97cbacd3fbaadfcebca76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->